### PR TITLE
chore:  Declare the update() LC function as required

### DIFF
--- a/post-package.ps1
+++ b/post-package.ps1
@@ -1,5 +1,5 @@
 $distPath = "./dist"
-$indexPath = Resolve-Path $distPath/index.d.ts
 $typesPath = Resolve-Path $distPath/wjfe-single-spa-svelte.d.ts
+$indexPath = Resolve-Path $distPath/index.d.ts
 Get-Content $indexPath | Where-Object { $_ -ne '' } | Add-Content -Path $typesPath -Encoding UTF8
 Remove-Item $indexPath

--- a/src/lib/wjfe-single-spa-svelte.d.ts
+++ b/src/lib/wjfe-single-spa-svelte.d.ts
@@ -34,7 +34,7 @@ export type SspaLifeCycles<TProps extends Record<string, any> = Record<string, a
      * @param props Updated set of properties for the parcel.
      * @returns A promise that resolves once the update has completed.
      */
-    update?: (props: TProps) => Promise<void>;
+    update: (props: TProps) => Promise<void>;
 };
 
 /**


### PR DESCRIPTION
- This allows people to not worry about TS saying `update()` is possibly undefined.