### PR TITLE
feat: Make mountParcel and singleSpa available through context

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ resulting functions should be conformant to what you are used to with `single-sp
 
 ## The Options Parameter
 
+> Since **v0.4.0**
+
 As seen in the Quickstart, `singleSpaSvelte`'s third parameter is named "options".  It accepts 3 properties:
 
 + `preMount`:  Optional function that is run just before mounting the Svelte component.
@@ -92,15 +94,16 @@ For a `single-spa` parcel to be successfully mounted, 2 things are needed:
 1. The parcel configuration object or a function that returns it.
 2. The `mountParcel` or `mountRootParcel` function.
 
+> [!IMPORTANT]
+> It is recommended to implement the factory pattern for the lifecycle functions when it comes to parcels.  See this 
+> [GitHub issue](https://github.com/single-spa/single-spa-svelte/issues/28) opened for the Svelte v4 version of this 
+> package for details on how to implement a factory function.
+
 The former is just the parcel's lifecycles, while the latter is the `mountParcel` function that `single-spa` injects 
 into every micro-frontend as a property, or the library's `mountRootParcel` function that is directly imported from 
 `single-spa`.
 
-> **IMPORTANT**:  It is recommended to implement the factory pattern for the lifecycle functions when it comes to 
-> parcels.  See this [GitHub issue](https://github.com/single-spa/single-spa-svelte/issues/28) opened for the Svelte 
-> v4 version of this package for details on how to implement a factory function.
+> Since **v0.5.0**
 
-In the future, an automatic or semi-automatic mechanism to get a hold of `mountParcel` could be implemented in order 
-to simplify the component's use.  There is an [open discussion](https://github.com/WJSoftware/wjfe-single-spa-svelte/discussions/1) 
-where anyone can participate with ideas or anything else.  **Remember**:  Participation is what makes open source 
-software great.
+The `sspa.mountParcel` property is, under normal circumstances, unneeded because this package makes it available 
+through context.  You should only ever care about the `sspa.config` property.

--- a/README.md
+++ b/README.md
@@ -84,30 +84,30 @@ parcels in Svelte v5 projects.  It works quite similarly to `<svelte:component>`
 markup and then via props, the component and its properties are set.
 
 ```html
-<SspaParcel sspa={{ config: parcelConfig, mountParcel: mountParcelFromSingleSpa }} {...restOfParcelProperties} />
+<SspaParcel sspa={{ config: parcelConfig }} {...restOfParcelProperties} />
 ```
+
+You can collect the parcel properties in an object and then spread them as in the example above, or you may 
+individually specify them in markup as it is normally done with other components.
 
 ### The sspa Property
 
-For a `single-spa` parcel to be successfully mounted, 2 things are needed:
+For a `single-spa` parcel to be successfully mounted using `SspaParcel`, the parcel configuration object or a function 
+that returns it must be provided.  The purpose of the `sspa` property is to allow passing this requirement.
 
-1. The parcel configuration object or a function that returns it.
-2. The `mountParcel` or `mountRootParcel` function.
+The `sspa` property is an object in order to avoid reserving property names that may collide with the property names of 
+the parcel component being mounted.  It only has one property:  `sspa.config`.  In the future and if required, any 
+new properties will be defined inside this `sspa` object property that serves as namespace.
 
 > [!IMPORTANT]
 > It is recommended to implement the factory pattern for the lifecycle functions when it comes to parcels.  See this 
 > [GitHub issue](https://github.com/single-spa/single-spa-svelte/issues/28) opened for the Svelte v4 version of this 
 > package for details on how to implement a factory function.
 
-> Since **v0.5.0**
-
-Out of the two requirements, only the first one (parcel configuration object or a function that returns it) needs to be 
-provided in code because `mountParcel` is automatically provided by this package.
-
 ## The single-spa Context
 
 > Since **v0.5.0**
 
-The entire `single-spa` library instance and the `mountParcel` functions are available via context.  import 
-`getSingleSpaContext` and use it to obtain the context.  Remember to use this function in the initialization code of a 
+The entire `single-spa` library instance and the `mountParcel` function are available via context.  If needed, import  
+`getSingleSpaContext` and call it to obtain the context.  Remember to use this function in the initialization code of a 
 component.

--- a/README.md
+++ b/README.md
@@ -99,11 +99,15 @@ For a `single-spa` parcel to be successfully mounted, 2 things are needed:
 > [GitHub issue](https://github.com/single-spa/single-spa-svelte/issues/28) opened for the Svelte v4 version of this 
 > package for details on how to implement a factory function.
 
-The former is just the parcel's lifecycles, while the latter is the `mountParcel` function that `single-spa` injects 
-into every micro-frontend as a property, or the library's `mountRootParcel` function that is directly imported from 
-`single-spa`.
+> Since **v0.5.0**
+
+Out of the two requirements, only the first one (parcel configuration object or a function that returns it) needs to be 
+provided in code because `mountParcel` is automatically provided by this package.
+
+## The single-spa Context
 
 > Since **v0.5.0**
 
-The `sspa.mountParcel` property is, under normal circumstances, unneeded because this package makes it available 
-through context.  You should only ever care about the `sspa.config` property.
+The entire `single-spa` library instance and the `mountParcel` functions are available via context.  import 
+`getSingleSpaContext` and use it to obtain the context.  Remember to use this function in the initialization code of a 
+component.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ As seen in the Quickstart, `singleSpaSvelte`'s third parameter is named "options
 
 + `preMount`:  Optional function that is run just before mounting the Svelte component.
 + `postUnmount`:  Optionsl function that is run immediately after unmounting the Svelte component.
-+ `svelteOptions`:  Optional set of options for Svelte's `mount` function.
++ `mountOptions`:  Optional set of options for Svelte's `mount` function.
 
 For details on the last one, refer to Svelte's documentation.  All properties are accepted, except for `target`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -611,208 +611,224 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
-			"integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.5.tgz",
+			"integrity": "sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
-			"integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.5.tgz",
+			"integrity": "sha512-S4pit5BP6E5R5C8S6tgU/drvgjtYW76FBuG6+ibG3tMvlD1h9LHVF9KmlmaUBQ8Obou7hEyS+0w+IR/VtxwNMQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
-			"integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.5.tgz",
+			"integrity": "sha512-250ZGg4ipTL0TGvLlfACkIxS9+KLtIbn7BCZjsZj88zSg2Lvu3Xdw6dhAhfe/FjjXPVNCtcSp+WZjVsD3a/Zlw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
-			"integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.5.tgz",
+			"integrity": "sha512-D8brJEFg5D+QxFcW6jYANu+Rr9SlKtTenmsX5hOSzNYVrK5oLAEMTUgKWYJP+wdKyCdeSwnapLsn+OVRFycuQg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
-			"integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.5.tgz",
+			"integrity": "sha512-PNqXYmdNFyWNg0ma5LdY8wP+eQfdvyaBAojAXgO7/gs0Q/6TQJVXAXe8gwW9URjbS0YAammur0fynYGiWsKlXw==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
-			"integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.5.tgz",
+			"integrity": "sha512-kSSCZOKz3HqlrEuwKd9TYv7vxPYD77vHSUvM2y0YaTGnFc8AdI5TTQRrM1yIp3tXCKrSL9A7JLoILjtad5t8pQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
-			"integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.5.tgz",
+			"integrity": "sha512-oTXQeJHRbOnwRnRffb6bmqmUugz0glXaPyspp4gbQOPVApdpRrY/j7KP3lr7M8kTfQTyrBUzFjj5EuHAhqH4/w==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
-			"integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.5.tgz",
+			"integrity": "sha512-qnOTIIs6tIGFKCHdhYitgC2XQ2X25InIbZFor5wh+mALH84qnFHvc+vmWUpyX97B0hNvwNUL4B+MB8vJvH65Fw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
-			"integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.5.tgz",
+			"integrity": "sha512-TMYu+DUdNlgBXING13rHSfUc3Ky5nLPbWs4bFnT+R6Vu3OvXkTkixvvBKk8uO4MT5Ab6lC3U7x8S8El2q5o56w==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
-			"integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.5.tgz",
+			"integrity": "sha512-PTQq1Kz22ZRvuhr3uURH+U/Q/a0pbxJoICGSprNLAoBEkyD3Sh9qP5I0Asn0y0wejXQBbsVMRZRxlbGFD9OK4A==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
-			"integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.5.tgz",
+			"integrity": "sha512-bR5nCojtpuMss6TDEmf/jnBnzlo+6n1UhgwqUvRoe4VIotC7FG1IKkyJbwsT7JDsF2jxR+NTnuOwiGv0hLyDoQ==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
-			"integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.5.tgz",
+			"integrity": "sha512-N0jPPhHjGShcB9/XXZQWuWBKZQnC1F36Ce3sDqWpujsGjDz/CQtOL9LgTrJ+rJC8MJeesMWrMWVLKKNR/tMOCA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
-			"integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.5.tgz",
+			"integrity": "sha512-uBa2e28ohzNNwjr6Uxm4XyaA1M/8aTgfF2T7UIlElLaeXkgpmIJ2EitVNQxjO9xLLLy60YqAgKn/AqSpCUkE9g==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
-			"integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.5.tgz",
+			"integrity": "sha512-RXT8S1HP8AFN/Kr3tg4fuYrNxZ/pZf1HemC5Tsddc6HzgGnJm0+Lh5rAHJkDuW3StI0ynNXukidROMXYl6ew8w==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
-			"integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.5.tgz",
+			"integrity": "sha512-ElTYOh50InL8kzyUD6XsnPit7jYCKrphmddKAe1/Ytt74apOxDq5YEcbsiKs0fR3vff3jEneMM+3I7jbqaMyBg==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
-			"integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.5.tgz",
+			"integrity": "sha512-+lvL/4mQxSV8MukpkKyyvfwhH266COcWlXE/1qxwN08ajovta3459zrjLghYMgDerlzNwLAcFpvU+WWE5y6nAQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -823,6 +839,7 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.5.tgz",
 			"integrity": "sha512-27LR+uKccZ62lgq4N/hvyU2G+hTP9fxWEAfnZcl70HnyfAjMSsGk1z/SjAPXNCD1mVJIE7IFu3TQ8cQ/UH3c0A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"import-meta-resolve": "^4.1.0"
 			},
@@ -831,15 +848,16 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.5.28",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.28.tgz",
-			"integrity": "sha512-/O7pvFGBsQPcFa9UrW8eUC5uHTOXLsUp3SN0dY6YmRAL9nfPSrJsSJk//j5vMpinSshzUjteAFcfQTU+04Ka1w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.6.1.tgz",
+			"integrity": "sha512-QFlch3GPGZYidYhdRAub0fONw8UTguPICFHUSPxNkA/jdlU1p6C6yqq19J1QWdxIHS2El/ycDCGrHb3EAiMNqg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
-				"devalue": "^5.0.0",
+				"devalue": "^5.1.0",
 				"esm-env": "^1.0.0",
 				"import-meta-resolve": "^4.1.0",
 				"kleur": "^4.1.5",
@@ -1167,20 +1185,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/aria-query": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1225,19 +1229,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/binary-extensions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1246,19 +1237,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/cac": {
@@ -1316,9 +1294,9 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-			"integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1474,9 +1452,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.0.0.tgz",
-			"integrity": "sha512-gO+/OMXF7488D+u3ue+G7Y4AA3ZmUnB3eHJXmBTgNHvr4ZNzl36A0ZtG+XCRNYCkYx/bFmw4qtkoFLa+wSrwAA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
+			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1591,19 +1569,6 @@
 				}
 			}
 		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -1670,19 +1635,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/globalyzer": {
@@ -1806,52 +1758,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"binary-extensions": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-glob": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-extglob": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -1881,6 +1787,7 @@
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
 			"integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cssstyle": "^4.1.0",
 				"data-urls": "^5.0.0",
@@ -2065,16 +1972,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/npm-bundled": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-2.0.1.tgz",
@@ -2118,9 +2015,9 @@
 			}
 		},
 		"node_modules/nwsapi": {
-			"version": "2.2.12",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
-			"integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
+			"version": "2.2.13",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
+			"integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2181,19 +2078,6 @@
 			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
 		},
 		"node_modules/postcss": {
 			"version": "8.4.47",
@@ -2312,12 +2196,13 @@
 			"license": "MIT"
 		},
 		"node_modules/rollup": {
-			"version": "4.22.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
-			"integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
+			"version": "4.22.5",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.5.tgz",
+			"integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "1.0.5"
+				"@types/estree": "1.0.6"
 			},
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -2327,31 +2212,24 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.22.4",
-				"@rollup/rollup-android-arm64": "4.22.4",
-				"@rollup/rollup-darwin-arm64": "4.22.4",
-				"@rollup/rollup-darwin-x64": "4.22.4",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
-				"@rollup/rollup-linux-arm-musleabihf": "4.22.4",
-				"@rollup/rollup-linux-arm64-gnu": "4.22.4",
-				"@rollup/rollup-linux-arm64-musl": "4.22.4",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
-				"@rollup/rollup-linux-riscv64-gnu": "4.22.4",
-				"@rollup/rollup-linux-s390x-gnu": "4.22.4",
-				"@rollup/rollup-linux-x64-gnu": "4.22.4",
-				"@rollup/rollup-linux-x64-musl": "4.22.4",
-				"@rollup/rollup-win32-arm64-msvc": "4.22.4",
-				"@rollup/rollup-win32-ia32-msvc": "4.22.4",
-				"@rollup/rollup-win32-x64-msvc": "4.22.4",
+				"@rollup/rollup-android-arm-eabi": "4.22.5",
+				"@rollup/rollup-android-arm64": "4.22.5",
+				"@rollup/rollup-darwin-arm64": "4.22.5",
+				"@rollup/rollup-darwin-x64": "4.22.5",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.22.5",
+				"@rollup/rollup-linux-arm-musleabihf": "4.22.5",
+				"@rollup/rollup-linux-arm64-gnu": "4.22.5",
+				"@rollup/rollup-linux-arm64-musl": "4.22.5",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.5",
+				"@rollup/rollup-linux-riscv64-gnu": "4.22.5",
+				"@rollup/rollup-linux-s390x-gnu": "4.22.5",
+				"@rollup/rollup-linux-x64-gnu": "4.22.5",
+				"@rollup/rollup-linux-x64-musl": "4.22.5",
+				"@rollup/rollup-win32-arm64-msvc": "4.22.5",
+				"@rollup/rollup-win32-ia32-msvc": "4.22.5",
+				"@rollup/rollup-win32-x64-msvc": "4.22.5",
 				"fsevents": "~2.3.2"
 			}
-		},
-		"node_modules/rollup/node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/rrweb-cssom": {
 			"version": "0.7.1",
@@ -2421,9 +2299,9 @@
 			"license": "ISC"
 		},
 		"node_modules/single-spa": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/single-spa/-/single-spa-6.0.2.tgz",
-			"integrity": "sha512-xCq58THg6Y3mJ94xgZhi6AtqN9IUfU/Pxb7ii9Qv8wiINlvtlXrTTMcTZ4zpr+M/CdpUbp5KmsqGmDVPwht50g==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/single-spa/-/single-spa-6.0.3.tgz",
+			"integrity": "sha512-pXlwHXHhs3hx/MnGQHBLdFCVAN2rlm9TLBKazbDMyZ25QRxoen2vlUZ47MyXKa9K8Gd5UZs/gkuQad4TGbViwg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2480,9 +2358,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.0.0-next.257",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.257.tgz",
-			"integrity": "sha512-fiTimH9UbJ0aNUcsOyaRgq4MZdmgN6lv3sQ2sOMv9V6haK0emsmYCm8Pw10+ej6FhXGALxuWvNdoi7VKMaeIIA==",
+			"version": "5.0.0-next.260",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.260.tgz",
+			"integrity": "sha512-TGcvG71DUklf5P4UmJxOQiVxWYLPp4c6o+NUjmVMsAXKsCMXOTXw+QpnmEWw5D95Sj7SrmAGeIT+p/uvHAUZXg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2505,13 +2383,14 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.2.tgz",
-			"integrity": "sha512-w2yqcG9ELJe2RJCnAvB7v0OgkHhL3czzz/tVoxGFfO6y4mOrF6QHCDhXijeXzsU7LVKEwWS3Qd9tza4JBuDxqA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.4.tgz",
+			"integrity": "sha512-AcHWIPuZb1mh/jKoIrww0ebBPpAvwWd1bfXCnwC2dx4OkydNMaiG//+Xnry91RJMHFH7CiE+6Y2p332DRIaOXQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"chokidar": "^3.4.1",
+				"chokidar": "^4.0.1",
 				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4"
@@ -2527,44 +2406,6 @@
 				"typescript": ">=5.0.0"
 			}
 		},
-		"node_modules/svelte-check/node_modules/chokidar": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
-			},
-			"engines": {
-				"node": ">= 8.10.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/svelte-check/node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
-			"engines": {
-				"node": ">=8.10.0"
-			}
-		},
 		"node_modules/svelte/node_modules/aria-query": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2576,9 +2417,9 @@
 			}
 		},
 		"node_modules/svelte2tsx": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.19.tgz",
-			"integrity": "sha512-PME/9mILn9wOihtk2dxu9tmf2+B9X6oWuqYPJRKSjqU4wq3Pc6+fOuYV7T3H+QF5afmA1oDobfXC6dzmK9NAVw==",
+			"version": "0.7.21",
+			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.21.tgz",
+			"integrity": "sha512-cdYR5gYBK0Ys3/jzGu9yfW9oxGLtLAnxcKtS7oJy2pjLhLLYSZcWeeeuaY9SMULwlqMZ1HfngGH3n5VdquRC3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2653,35 +2494,24 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "6.1.47",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.47.tgz",
-			"integrity": "sha512-R/K2tZ5MiY+mVrnSkNJkwqYT2vUv1lcT6wJvd2emGaMJ7PHUGRY4e3tUsdFCXgqxi2QgbHjL3yJgXCo40v9Hxw==",
+			"version": "6.1.48",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.48.tgz",
+			"integrity": "sha512-SPbnh1zaSzi/OsmHb1vrPNnYuwJbdWjwo5TbBYYMlTtH3/1DSb41t8bcSxkwDmmbG2q6VLPVvQc7Yf23T+1EEw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.47"
+				"tldts-core": "^6.1.48"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.47",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
-			"integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA==",
-			"dev": true
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"version": "6.1.48",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.48.tgz",
+			"integrity": "sha512-3gD9iKn/n2UuFH1uilBviK9gvTNT6iYwdqrj1Vr5mh8FuelvpRNaYVH4pNYqUgOGU4aAdL9X35eLuuj0gRsx+A==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
@@ -2698,6 +2528,7 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
 			"integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tldts": "^6.1.32"
 			},
@@ -2740,9 +2571,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.7",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.7.tgz",
-			"integrity": "sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==",
+			"version": "5.4.8",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+			"integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wjfe/single-spa-svelte",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wjfe/single-spa-svelte",
-			"version": "0.4.0",
+			"version": "0.5.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -604,16 +604,16 @@
 			}
 		},
 		"node_modules/@polka/url": {
-			"version": "1.0.0-next.25",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
-			"integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
+			"version": "1.0.0-next.28",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
+			"integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.2.tgz",
-			"integrity": "sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.3.tgz",
+			"integrity": "sha512-Po+UujLih7BSLvAWcPWTKgtmaFdzkzgPXoJ2w4vNPbIgUJEjhzdNgei/2X6RyWExXuhr1c68kHPySdXH8F+EWA==",
 			"cpu": [
 				"arm"
 			],
@@ -625,9 +625,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.2.tgz",
-			"integrity": "sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.3.tgz",
+			"integrity": "sha512-52cRgrMaz2JxX0a/wfnnrkToHGzMWrI18X5n+e73Hz/BFPEV4QhglW5z8cOs6kyYHB9tQPo7kjMjFhxwj72SXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -639,9 +639,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.2.tgz",
-			"integrity": "sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.3.tgz",
+			"integrity": "sha512-3o4PxCB4dQyFXanB/rfaLk37mX/ZKo8tIwULy37H8NLmcQOoH8reWSG2qVuyEKjLqAo14hVPTsRIXxjqciuMgQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -653,9 +653,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.2.tgz",
-			"integrity": "sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.3.tgz",
+			"integrity": "sha512-6MvaCC++JZcKWZ/BdgugJSnt03DMFwoKhAb4QADDkV+iQR/utqPrEgisAdleTb21MrgBi5XcgMPiUtrhNlNSTw==",
 			"cpu": [
 				"x64"
 			],
@@ -667,9 +667,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.2.tgz",
-			"integrity": "sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.3.tgz",
+			"integrity": "sha512-tY4B/12eysJZ9gdOAKQbTsWC+3YVpopcxNvXxXUg6+OMSlVh0raMwlWqQNIxfGPqanuiR5JOes3dAVckt/NMow==",
 			"cpu": [
 				"arm"
 			],
@@ -681,9 +681,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.2.tgz",
-			"integrity": "sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.3.tgz",
+			"integrity": "sha512-nxBawr7RUK3SelngWI0y136bSCVLt2HkPuNiNEek25PDgmh/mdTJRVgxMmr76mmJesewImOGQBWhw3kpZ5Jv7Q==",
 			"cpu": [
 				"arm"
 			],
@@ -695,9 +695,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.2.tgz",
-			"integrity": "sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.3.tgz",
+			"integrity": "sha512-kVrJmt7kSQBptiuKccz+QVHTkRz7UhQuKhmXtCFbG8RukSfvbrFDfanYe5jaCUc0hDUE4T40sVPsyrwbnhlf+Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -709,9 +709,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.2.tgz",
-			"integrity": "sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.3.tgz",
+			"integrity": "sha512-yx7Xei61efYQ1JZMZ0WOA3vRwEHFU0LlzaEER2cVejr5EplBmOykBeHSeWnngeVNRASgiHS36tA8jlo6AJ9Shg==",
 			"cpu": [
 				"arm64"
 			],
@@ -723,9 +723,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.2.tgz",
-			"integrity": "sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.3.tgz",
+			"integrity": "sha512-QJTk7pEUN1T1OGIkHbfeQd/+wthw+kmXrmNZUrDvDznKxgpgS+Uqbi+egux6UdEXuuaxhavm5L+aotbTuWqqaQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -737,9 +737,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.2.tgz",
-			"integrity": "sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.3.tgz",
+			"integrity": "sha512-aXFDDzVq2HTT7GsV5s8rpsH1Mk6WlZOxxsd2H/4LP4gJ8Fu9+C+O5k2ccmXjSh7IPc8R0u1YdeGETARcJvgoPg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -751,9 +751,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.2.tgz",
-			"integrity": "sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.3.tgz",
+			"integrity": "sha512-pesLBj+872ZyL43ALKua0syvFLYY/Z5cVsB5xdBGkYaRYjxwIDze1QN9Cxi8tlAhJGblz41D4507DEraITDvkw==",
 			"cpu": [
 				"s390x"
 			],
@@ -765,9 +765,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.2.tgz",
-			"integrity": "sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.3.tgz",
+			"integrity": "sha512-QWAgO5V7E6n3w4a1H7qrqA7k4IDqGYjT/P/wTV1b5o3wifLB1sYmuXw1urw4HWP3KmZxIKb5uEwZPW6Ec4l9DA==",
 			"cpu": [
 				"x64"
 			],
@@ -779,9 +779,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.2.tgz",
-			"integrity": "sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.3.tgz",
+			"integrity": "sha512-fUL9CVfu2DLycemee7QoYHpABaLUJh5QM3naBUGlZoysaSFVvAbFju0wBHcY73IGdUb2MI2Yh8sSjIPAiUs+Kg==",
 			"cpu": [
 				"x64"
 			],
@@ -793,9 +793,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.2.tgz",
-			"integrity": "sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.3.tgz",
+			"integrity": "sha512-IWxGO/k2gysJPXDmUAqmpcayaX6P+RB10JXJrV4QjcN7ipKWFcHYfTDG1EGyXLEZhHMQe3Ed0OjvPe4JYZvINA==",
 			"cpu": [
 				"arm64"
 			],
@@ -807,9 +807,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.2.tgz",
-			"integrity": "sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.3.tgz",
+			"integrity": "sha512-liDr0/niP4/7bhiZwrjl2nAARj7gwden3G2DdOJImMbYrjp2C2cYKxEPViOIs4ci6ugcan6TcakxfqJfcb9SJQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -821,9 +821,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.2.tgz",
-			"integrity": "sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.3.tgz",
+			"integrity": "sha512-4fEwOjO95h0RuNrAYKXIAd1ZWTKUNN+PZwVBHGGdekfeHldP7l2V/iqKPGinMKv5g+KJjcJe9BD6ooBpS/EUJQ==",
 			"cpu": [
 				"x64"
 			],
@@ -835,9 +835,9 @@
 			]
 		},
 		"node_modules/@sveltejs/adapter-auto": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.4.tgz",
-			"integrity": "sha512-a64AKYbfTUrVwU0xslzv1Jf3M8bj0IwhptaXmhgIkjXspBXhD0od9JiItQHchijpLMGdEDcYBlvqySkEawv6mQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.5.tgz",
+			"integrity": "sha512-27LR+uKccZ62lgq4N/hvyU2G+hTP9fxWEAfnZcl70HnyfAjMSsGk1z/SjAPXNCD1mVJIE7IFu3TQ8cQ/UH3c0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -848,9 +848,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.5.26",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.26.tgz",
-			"integrity": "sha512-8l1JTIM2L+bS8ebq1E+nGjv/YSKSnD9Q19bYIUkc41vaEG2JjVUx6ikvPIJv2hkQAuqJLzoPrXlKk4KcyWOv3Q==",
+			"version": "2.5.28",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.5.28.tgz",
+			"integrity": "sha512-/O7pvFGBsQPcFa9UrW8eUC5uHTOXLsUp3SN0dY6YmRAL9nfPSrJsSJk//j5vMpinSshzUjteAFcfQTU+04Ka1w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -885,6 +885,7 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.3.5.tgz",
 			"integrity": "sha512-fxWSG+pJHxWwcKltG+JoQ+P1CPO7NHVuZD1Gchi/1mNN6C60yD/voHeeXlqr0HHGkvIrpAjRIHLjsavI77Qsiw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"kleur": "^4.1.5",
@@ -900,34 +901,6 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
-			}
-		},
-		"node_modules/@sveltejs/package/node_modules/chokidar": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-			"integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
-			"dev": true,
-			"dependencies": {
-				"readdirp": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14.16.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@sveltejs/package/node_modules/readdirp": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
-			"integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 14.16.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1031,9 +1004,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
@@ -1041,6 +1014,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.1.tgz",
 			"integrity": "sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/spy": "2.1.1",
 				"@vitest/utils": "2.1.1",
@@ -1056,6 +1030,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.1.tgz",
 			"integrity": "sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/spy": "^2.1.0-beta.1",
 				"estree-walker": "^3.0.3",
@@ -1083,6 +1058,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
 			"integrity": "sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tinyrainbow": "^1.2.0"
 			},
@@ -1095,6 +1071,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.1.tgz",
 			"integrity": "sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/utils": "2.1.1",
 				"pathe": "^1.1.2"
@@ -1108,6 +1085,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.1.tgz",
 			"integrity": "sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "2.1.1",
 				"magic-string": "^0.30.11",
@@ -1122,6 +1100,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.1.tgz",
 			"integrity": "sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"tinyspy": "^3.0.0"
 			},
@@ -1134,6 +1113,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.1.tgz",
 			"integrity": "sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "2.1.1",
 				"loupe": "^3.1.1",
@@ -1223,6 +1203,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"dequal": "^2.0.3"
@@ -1233,6 +1214,7 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
 			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			}
@@ -1302,6 +1284,7 @@
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
 			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -1311,6 +1294,7 @@
 			"resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
 			"integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"assertion-error": "^2.0.1",
 				"check-error": "^2.1.1",
@@ -1344,33 +1328,25 @@
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
 			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
+			"integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
+				"readdirp": "^4.0.1"
 			},
 			"engines": {
-				"node": ">= 8.10.0"
+				"node": ">= 14.16.0"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1480,6 +1456,7 @@
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
 			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -1508,6 +1485,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -1611,8 +1589,24 @@
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
+			"integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/fill-range": {
@@ -1670,6 +1664,7 @@
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
 			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
@@ -1962,6 +1957,7 @@
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
 			"integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"get-func-name": "^2.0.1"
 			}
@@ -2185,13 +2181,15 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
 			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pathval": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
 			"integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 14.16"
 			}
@@ -2217,9 +2215,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.45",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-			"integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+			"version": "8.4.47",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+			"integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2238,8 +2236,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
-				"picocolors": "^1.0.1",
-				"source-map-js": "^1.2.0"
+				"picocolors": "^1.1.0",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -2285,6 +2283,7 @@
 			"resolved": "https://registry.npmjs.org/publint/-/publint-0.2.11.tgz",
 			"integrity": "sha512-/kxbd+sD/uEG515N/ZYpC6gYs8h89cQ4UIsAq1y6VT4qlNh8xmiSwcP2xU2MbzXFl8J0l2IdONKFweLfYoqhcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"npm-packlist": "^5.1.3",
 				"picocolors": "^1.1.0",
@@ -2325,16 +2324,17 @@
 			"license": "MIT"
 		},
 		"node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+			"integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
 			"engines": {
-				"node": ">=8.10.0"
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/regenerator-runtime": {
@@ -2352,9 +2352,9 @@
 			"license": "MIT"
 		},
 		"node_modules/rollup": {
-			"version": "4.21.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
-			"integrity": "sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.3.tgz",
+			"integrity": "sha512-RCKDv63O5cc4G/erEqWsi9U0DHbVlQ+5ww5BawleRHcSB4Ozqwf7eBE8lIywUtZtBebGxed3XydVDaQoBnsk5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2368,24 +2368,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.21.2",
-				"@rollup/rollup-android-arm64": "4.21.2",
-				"@rollup/rollup-darwin-arm64": "4.21.2",
-				"@rollup/rollup-darwin-x64": "4.21.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.21.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.21.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.21.2",
-				"@rollup/rollup-linux-arm64-musl": "4.21.2",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.21.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.21.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.21.2",
-				"@rollup/rollup-linux-x64-gnu": "4.21.2",
-				"@rollup/rollup-linux-x64-musl": "4.21.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.21.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.21.2",
-				"@rollup/rollup-win32-x64-msvc": "4.21.2",
+				"@rollup/rollup-android-arm-eabi": "4.22.3",
+				"@rollup/rollup-android-arm64": "4.22.3",
+				"@rollup/rollup-darwin-arm64": "4.22.3",
+				"@rollup/rollup-darwin-x64": "4.22.3",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.22.3",
+				"@rollup/rollup-linux-arm-musleabihf": "4.22.3",
+				"@rollup/rollup-linux-arm64-gnu": "4.22.3",
+				"@rollup/rollup-linux-arm64-musl": "4.22.3",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.3",
+				"@rollup/rollup-linux-riscv64-gnu": "4.22.3",
+				"@rollup/rollup-linux-s390x-gnu": "4.22.3",
+				"@rollup/rollup-linux-x64-gnu": "4.22.3",
+				"@rollup/rollup-linux-x64-musl": "4.22.3",
+				"@rollup/rollup-win32-arm64-msvc": "4.22.3",
+				"@rollup/rollup-win32-ia32-msvc": "4.22.3",
+				"@rollup/rollup-win32-x64-msvc": "4.22.3",
 				"fsevents": "~2.3.2"
 			}
+		},
+		"node_modules/rollup/node_modules/@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/rrweb-cssom": {
 			"version": "0.7.1",
@@ -2458,7 +2465,8 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/single-spa/-/single-spa-6.0.2.tgz",
 			"integrity": "sha512-xCq58THg6Y3mJ94xgZhi6AtqN9IUfU/Pxb7ii9Qv8wiINlvtlXrTTMcTZ4zpr+M/CdpUbp5KmsqGmDVPwht50g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
@@ -2513,9 +2521,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.0.0-next.244",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.244.tgz",
-			"integrity": "sha512-whSOcKdpuAFd5xD9J2EhuHeRs4J4nHis6NSUKRXpC3HQoCmsoKhyIldMjiv6QFkQpe6QMsid8lwvgLXkZTSC/A==",
+			"version": "5.0.0-next.257",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.257.tgz",
+			"integrity": "sha512-fiTimH9UbJ0aNUcsOyaRgq4MZdmgN6lv3sQ2sOMv9V6haK0emsmYCm8Pw10+ej6FhXGALxuWvNdoi7VKMaeIIA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2524,7 +2532,7 @@
 				"@types/estree": "^1.0.5",
 				"acorn": "^8.12.1",
 				"acorn-typescript": "^1.4.13",
-				"aria-query": "^5.3.0",
+				"aria-query": "^5.3.1",
 				"axobject-query": "^4.1.0",
 				"esm-env": "^1.0.0",
 				"esrap": "^1.2.2",
@@ -2538,9 +2546,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.1.tgz",
-			"integrity": "sha512-AuWnCZdREoOzMhoptHPUUPYUxLNdXSkoZnPnlv19SZJJimRzLmjjZLKsOiRB4AnhgX+56/WSEdvkWXI/q2BSsA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.2.tgz",
+			"integrity": "sha512-w2yqcG9ELJe2RJCnAvB7v0OgkHhL3czzz/tVoxGFfO6y4mOrF6QHCDhXijeXzsU7LVKEwWS3Qd9tza4JBuDxqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2561,40 +2569,58 @@
 				"typescript": ">=5.0.0"
 			}
 		},
-		"node_modules/svelte-check/node_modules/fdir": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
-			"integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+		"node_modules/svelte-check/node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
 			"dev": true,
 			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
 			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">= 8.10.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/svelte-check/node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/svelte/node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/svelte2tsx": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.18.tgz",
-			"integrity": "sha512-PCOhH7uQaV472ZvNAcnkvShjFRMMkKUc/eNJImQMH9T4CyHeQpdatedFrEjaMCsweFb/oo3a6bv4qtdfaCPw8g==",
+			"version": "0.7.19",
+			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.19.tgz",
+			"integrity": "sha512-PME/9mILn9wOihtk2dxu9tmf2+B9X6oWuqYPJRKSjqU4wq3Pc6+fOuYV7T3H+QF5afmA1oDobfXC6dzmK9NAVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2635,7 +2661,8 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.0.tgz",
 			"integrity": "sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tinypool": {
 			"version": "1.0.1",
@@ -2652,6 +2679,7 @@
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
 			"integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -2661,6 +2689,7 @@
 			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
 			"integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -2760,10 +2789,11 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.6.tgz",
-			"integrity": "sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==",
+			"version": "5.4.7",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.7.tgz",
+			"integrity": "sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -2823,6 +2853,7 @@
 			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.1.tgz",
 			"integrity": "sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cac": "^6.7.14",
 				"debug": "^4.3.6",
@@ -2863,6 +2894,7 @@
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
 			"integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@vitest/expect": "2.1.1",
 				"@vitest/mocker": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
 			"version": "0.4.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@sveltejs/adapter-auto": "^3.2.4",
-				"@sveltejs/kit": "^2.5.26",
+				"@sveltejs/adapter-auto": "^3.2.5",
+				"@sveltejs/kit": "^2.5.28",
 				"@sveltejs/package": "^2.3.5",
 				"@sveltejs/vite-plugin-svelte": "^4.0.0-next.7",
 				"@testing-library/svelte": "^5.2.1",
-				"jsdom": "^25.0.0",
+				"jsdom": "^25.0.1",
 				"publint": "^0.2.11",
 				"single-spa": "^6.0.2",
-				"svelte-check": "^4.0.1",
+				"svelte-check": "^4.0.2",
 				"tslib": "^2.7.0",
 				"typescript": "^5.6.2",
-				"vite": "^5.4.6",
+				"vite": "^5.4.7",
 				"vitest": "^2.1.1"
 			},
 			"peerDependencies": {
@@ -611,224 +611,208 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.3.tgz",
-			"integrity": "sha512-Po+UujLih7BSLvAWcPWTKgtmaFdzkzgPXoJ2w4vNPbIgUJEjhzdNgei/2X6RyWExXuhr1c68kHPySdXH8F+EWA==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
+			"integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.3.tgz",
-			"integrity": "sha512-52cRgrMaz2JxX0a/wfnnrkToHGzMWrI18X5n+e73Hz/BFPEV4QhglW5z8cOs6kyYHB9tQPo7kjMjFhxwj72SXg==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
+			"integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"android"
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.3.tgz",
-			"integrity": "sha512-3o4PxCB4dQyFXanB/rfaLk37mX/ZKo8tIwULy37H8NLmcQOoH8reWSG2qVuyEKjLqAo14hVPTsRIXxjqciuMgQ==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
+			"integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.3.tgz",
-			"integrity": "sha512-6MvaCC++JZcKWZ/BdgugJSnt03DMFwoKhAb4QADDkV+iQR/utqPrEgisAdleTb21MrgBi5XcgMPiUtrhNlNSTw==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
+			"integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.3.tgz",
-			"integrity": "sha512-tY4B/12eysJZ9gdOAKQbTsWC+3YVpopcxNvXxXUg6+OMSlVh0raMwlWqQNIxfGPqanuiR5JOes3dAVckt/NMow==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
+			"integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.3.tgz",
-			"integrity": "sha512-nxBawr7RUK3SelngWI0y136bSCVLt2HkPuNiNEek25PDgmh/mdTJRVgxMmr76mmJesewImOGQBWhw3kpZ5Jv7Q==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
+			"integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.3.tgz",
-			"integrity": "sha512-kVrJmt7kSQBptiuKccz+QVHTkRz7UhQuKhmXtCFbG8RukSfvbrFDfanYe5jaCUc0hDUE4T40sVPsyrwbnhlf+Q==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
+			"integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.3.tgz",
-			"integrity": "sha512-yx7Xei61efYQ1JZMZ0WOA3vRwEHFU0LlzaEER2cVejr5EplBmOykBeHSeWnngeVNRASgiHS36tA8jlo6AJ9Shg==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
+			"integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.3.tgz",
-			"integrity": "sha512-QJTk7pEUN1T1OGIkHbfeQd/+wthw+kmXrmNZUrDvDznKxgpgS+Uqbi+egux6UdEXuuaxhavm5L+aotbTuWqqaQ==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
+			"integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.3.tgz",
-			"integrity": "sha512-aXFDDzVq2HTT7GsV5s8rpsH1Mk6WlZOxxsd2H/4LP4gJ8Fu9+C+O5k2ccmXjSh7IPc8R0u1YdeGETARcJvgoPg==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
+			"integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.3.tgz",
-			"integrity": "sha512-pesLBj+872ZyL43ALKua0syvFLYY/Z5cVsB5xdBGkYaRYjxwIDze1QN9Cxi8tlAhJGblz41D4507DEraITDvkw==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
+			"integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.3.tgz",
-			"integrity": "sha512-QWAgO5V7E6n3w4a1H7qrqA7k4IDqGYjT/P/wTV1b5o3wifLB1sYmuXw1urw4HWP3KmZxIKb5uEwZPW6Ec4l9DA==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
+			"integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.3.tgz",
-			"integrity": "sha512-fUL9CVfu2DLycemee7QoYHpABaLUJh5QM3naBUGlZoysaSFVvAbFju0wBHcY73IGdUb2MI2Yh8sSjIPAiUs+Kg==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
+			"integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.3.tgz",
-			"integrity": "sha512-IWxGO/k2gysJPXDmUAqmpcayaX6P+RB10JXJrV4QjcN7ipKWFcHYfTDG1EGyXLEZhHMQe3Ed0OjvPe4JYZvINA==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
+			"integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.3.tgz",
-			"integrity": "sha512-liDr0/niP4/7bhiZwrjl2nAARj7gwden3G2DdOJImMbYrjp2C2cYKxEPViOIs4ci6ugcan6TcakxfqJfcb9SJQ==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
+			"integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
 			"cpu": [
 				"ia32"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.3.tgz",
-			"integrity": "sha512-4fEwOjO95h0RuNrAYKXIAd1ZWTKUNN+PZwVBHGGdekfeHldP7l2V/iqKPGinMKv5g+KJjcJe9BD6ooBpS/EUJQ==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
+			"integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
@@ -839,7 +823,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.5.tgz",
 			"integrity": "sha512-27LR+uKccZ62lgq4N/hvyU2G+hTP9fxWEAfnZcl70HnyfAjMSsGk1z/SjAPXNCD1mVJIE7IFu3TQ8cQ/UH3c0A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"import-meta-resolve": "^4.1.0"
 			},
@@ -853,7 +836,6 @@
 			"integrity": "sha512-/O7pvFGBsQPcFa9UrW8eUC5uHTOXLsUp3SN0dY6YmRAL9nfPSrJsSJk//j5vMpinSshzUjteAFcfQTU+04Ka1w==",
 			"dev": true,
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
@@ -1895,13 +1877,12 @@
 			"license": "MIT"
 		},
 		"node_modules/jsdom": {
-			"version": "25.0.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.0.tgz",
-			"integrity": "sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==",
+			"version": "25.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+			"integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"cssstyle": "^4.0.1",
+				"cssstyle": "^4.1.0",
 				"data-urls": "^5.0.0",
 				"decimal.js": "^10.4.3",
 				"form-data": "^4.0.0",
@@ -1914,7 +1895,7 @@
 				"rrweb-cssom": "^0.7.1",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.1.4",
+				"tough-cookie": "^5.0.0",
 				"w3c-xmlserializer": "^5.0.0",
 				"webidl-conversions": "^7.0.0",
 				"whatwg-encoding": "^3.1.1",
@@ -2271,13 +2252,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/psl": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/publint": {
 			"version": "0.2.11",
 			"resolved": "https://registry.npmjs.org/publint/-/publint-0.2.11.tgz",
@@ -2309,13 +2283,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/react-is": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -2344,19 +2311,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/rollup": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.3.tgz",
-			"integrity": "sha512-RCKDv63O5cc4G/erEqWsi9U0DHbVlQ+5ww5BawleRHcSB4Ozqwf7eBE8lIywUtZtBebGxed3XydVDaQoBnsk5Q==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
+			"integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.5"
 			},
@@ -2368,22 +2327,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.22.3",
-				"@rollup/rollup-android-arm64": "4.22.3",
-				"@rollup/rollup-darwin-arm64": "4.22.3",
-				"@rollup/rollup-darwin-x64": "4.22.3",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.22.3",
-				"@rollup/rollup-linux-arm-musleabihf": "4.22.3",
-				"@rollup/rollup-linux-arm64-gnu": "4.22.3",
-				"@rollup/rollup-linux-arm64-musl": "4.22.3",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.3",
-				"@rollup/rollup-linux-riscv64-gnu": "4.22.3",
-				"@rollup/rollup-linux-s390x-gnu": "4.22.3",
-				"@rollup/rollup-linux-x64-gnu": "4.22.3",
-				"@rollup/rollup-linux-x64-musl": "4.22.3",
-				"@rollup/rollup-win32-arm64-msvc": "4.22.3",
-				"@rollup/rollup-win32-ia32-msvc": "4.22.3",
-				"@rollup/rollup-win32-x64-msvc": "4.22.3",
+				"@rollup/rollup-android-arm-eabi": "4.22.4",
+				"@rollup/rollup-android-arm64": "4.22.4",
+				"@rollup/rollup-darwin-arm64": "4.22.4",
+				"@rollup/rollup-darwin-x64": "4.22.4",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
+				"@rollup/rollup-linux-arm-musleabihf": "4.22.4",
+				"@rollup/rollup-linux-arm64-gnu": "4.22.4",
+				"@rollup/rollup-linux-arm64-musl": "4.22.4",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
+				"@rollup/rollup-linux-riscv64-gnu": "4.22.4",
+				"@rollup/rollup-linux-s390x-gnu": "4.22.4",
+				"@rollup/rollup-linux-x64-gnu": "4.22.4",
+				"@rollup/rollup-linux-x64-musl": "4.22.4",
+				"@rollup/rollup-win32-arm64-msvc": "4.22.4",
+				"@rollup/rollup-win32-ia32-msvc": "4.22.4",
+				"@rollup/rollup-win32-x64-msvc": "4.22.4",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -2550,7 +2509,6 @@
 			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.2.tgz",
 			"integrity": "sha512-w2yqcG9ELJe2RJCnAvB7v0OgkHhL3czzz/tVoxGFfO6y4mOrF6QHCDhXijeXzsU7LVKEwWS3Qd9tza4JBuDxqA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"chokidar": "^3.4.1",
@@ -2694,6 +2652,24 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "6.1.47",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.47.tgz",
+			"integrity": "sha512-R/K2tZ5MiY+mVrnSkNJkwqYT2vUv1lcT6wJvd2emGaMJ7PHUGRY4e3tUsdFCXgqxi2QgbHjL3yJgXCo40v9Hxw==",
+			"dev": true,
+			"dependencies": {
+				"tldts-core": "^6.1.47"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.47",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
+			"integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA==",
+			"dev": true
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2718,19 +2694,15 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+			"integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
+				"tldts": "^6.1.32"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
@@ -2765,27 +2737,6 @@
 			},
 			"engines": {
 				"node": ">=14.17"
-			}
-		},
-		"node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wjfe/single-spa-svelte",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
 		"svelte": "^5.0.0 || ^5.0.0-next.1"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^3.2.4",
-		"@sveltejs/kit": "^2.5.26",
+		"@sveltejs/adapter-auto": "^3.2.5",
+		"@sveltejs/kit": "^2.5.28",
 		"@sveltejs/package": "^2.3.5",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.7",
 		"@testing-library/svelte": "^5.2.1",
-		"jsdom": "^25.0.0",
+		"jsdom": "^25.0.1",
 		"publint": "^0.2.11",
 		"single-spa": "^6.0.2",
-		"svelte-check": "^4.0.1",
+		"svelte-check": "^4.0.2",
 		"tslib": "^2.7.0",
 		"typescript": "^5.6.2",
-		"vite": "^5.4.6",
+		"vite": "^5.4.7",
 		"vitest": "^2.1.1"
 	},
 	"svelte": "./dist/index.js",

--- a/src/lib/SspaParcel/SspaParcel.svelte
+++ b/src/lib/SspaParcel/SspaParcel.svelte
@@ -107,16 +107,22 @@ function loadParcel() {
 }
 ```
 
-Mounting a parcel with no custom (or parcel-native) properties:
+### Mounting a parcel with no custom (or parcel-native) properties
+
+```html
+<SspaParcel sspa={{ config: loadParcel }} />
+```
+
+Or with an explicit  `mountParcel` function (which should be unnecessary even for root projects).
 
 ```html
 <SspaParcel sspa={{ mountParcel, config: loadParcel }} />
 ```
 
-Mounting a parcel with extra properties that are native to the parcel being mounted:
+### Mounting a parcel with extra properties that are native to the parcel being mounted
 
 ```html
-<SspaParcel sspa={{ mountParcel, config: loadParcel }} showSomething={true} onclick={() => console.log('clicked!')} />
+<SspaParcel sspa={{ config: loadParcel }} showSomething={true} onclick={() => console.log('clicked!')} />
 ```
 
 As seen in the above examples, event handlers can be passed as well thanks to Svelte v5's new design.  Yes, snippets 

--- a/src/lib/SspaParcel/SspaParcel.svelte
+++ b/src/lib/SspaParcel/SspaParcel.svelte
@@ -13,10 +13,6 @@
          */
         sspa: {
             /**
-             * The `mountParcel` function to use to mount the parcel.
-             */
-            mountParcel?: MountParcelFn;
-            /**
              * Parcel configuration object, or a function that returns a promise with the configuration object.
              */
             config: Parameters<MountParcelFn>[0];
@@ -32,8 +28,11 @@
     let firstRun = true;
 
     onMount(() => {
-        // The needed mountParcel() function may come from props or could be in context.
-        const mountParcelFn = sspa.mountParcel ?? getSingleSpaContext()?.mountParcel;
+        // The needed mountParcel() function from context.
+        const mountParcelFn = getSingleSpaContext()?.mountParcel;
+        if (typeof mountParcelFn !== 'function') {
+            throw new Error('Unexpected:  The single-spa context did not carry the "mountParcel" function.');
+        }
         parcel = mountParcelFn(sspa.config, {
             domElement: containerEl,
             ...restProps,
@@ -82,17 +81,8 @@ information.
 
 ## The `sspa` Prop
 
-This must be an object with one required and one optional properties:  The `mountParcel` function to use when mounting 
-the parcel, and the parcel configuration object (the object with the lifecycle functions).  The latter can also be a 
-function that returns a promise with said configuration object.  The former is the optional property; the latter is the 
-required one.
-
-### About `mountParcel`
-
-As you probably know, `mountParcel` is the function used to mount parcels.  This function is "calculated" specially 
-for every mounted micro-frontend.  This NPM package (`@wjfe/single-spa-svelte`) stores this function in context so 
-`SspaParcel` instances can automatically retrieve it.  This mechanism allows `sspa.mountParcel` to be optional (and 
-largely unnecessary).
+This must be an object with one required property:  The parcel configuration object (the object with the lifecycle 
+functions).  This can also be a function that returns a promise with said configuration object.
 
 ## Examples
 
@@ -111,12 +101,6 @@ function loadParcel() {
 
 ```html
 <SspaParcel sspa={{ config: loadParcel }} />
-```
-
-Or with an explicit  `mountParcel` function (which should be unnecessary even for root projects).
-
-```html
-<SspaParcel sspa={{ mountParcel, config: loadParcel }} />
 ```
 
 ### Mounting a parcel with extra properties that are native to the parcel being mounted

--- a/src/lib/SspaParcel/SspaParcel.svelte
+++ b/src/lib/SspaParcel/SspaParcel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { getSingleSpaContext } from "$lib/singleSpaContext.js";
     import type { MountParcelFn, Parcel } from "$lib/wjfe-single-spa-svelte.js";
     import { onMount } from "svelte";
 
@@ -12,10 +13,9 @@
          */
         sspa: {
             /**
-             * The mountParcel function to use to mount the parcel.  Pass the function received from single-spa if 
-             * available; otherwise you may use single-spa's mountRootParcel function.
+             * The `mountParcel` function to use to mount the parcel.
              */
-            mountParcel: MountParcelFn;
+            mountParcel?: MountParcelFn;
             /**
              * Parcel configuration object, or a function that returns a promise with the configuration object.
              */
@@ -32,7 +32,9 @@
     let firstRun = true;
 
     onMount(() => {
-        parcel = sspa.mountParcel(sspa.config, {
+        // The needed mountParcel() function may come from props or could be in context.
+        const mountParcelFn = sspa.mountParcel ?? getSingleSpaContext()?.mountParcel;
+        parcel = mountParcelFn(sspa.config, {
             domElement: containerEl,
             ...restProps,
         });
@@ -69,6 +71,8 @@
 <!--
 @component
 
+# SspaParcel
+
 The `SspaParcel` Svelte component can be used to embed `single-spa` parcel components.  Parcel components can be 
 written using any framework or library (React, Vue, Svelte, Lit, HTMX, etc.) as long as the final result is a module 
 that exports the parcel lifecycle functions.
@@ -78,9 +82,17 @@ information.
 
 ## The `sspa` Prop
 
-This must be an object with the two required pieces of information:  The `mountParcel` function to use when mounting 
+This must be an object with one required and one optional properties:  The `mountParcel` function to use when mounting 
 the parcel, and the parcel configuration object (the object with the lifecycle functions).  The latter can also be a 
-function that returns a promise with said configuration object.
+function that returns a promise with said configuration object.  The former is the optional property; the latter is the 
+required one.
+
+### About `mountParcel`
+
+As you probably know, `mountParcel` is the function used to mount parcels.  This function is "calculated" specially 
+for every mounted micro-frontend.  This NPM package (`@wjfe/single-spa-svelte`) stores this function in context so 
+`SspaParcel` instances can automatically retrieve it.  This mechanism allows `sspa.mountParcel` to be optional (and 
+largely unnecessary).
 
 ## Examples
 

--- a/src/lib/SspaParcel/SspaParcel.test.ts
+++ b/src/lib/SspaParcel/SspaParcel.test.ts
@@ -17,6 +17,7 @@ describe('SspaParcel', () => {
         };
 
         // Act.
+        // @ts-expect-error
         const act = () => render(SspaParcel, { sspa: { config } });
 
         // Assert.
@@ -41,6 +42,7 @@ describe('SspaParcel', () => {
         const mountParcel = vi.fn();
 
         // Act.
+        // @ts-expect-error
         render(SspaParcel, { sspa: { config, mountParcel } });
 
         // Assert.
@@ -62,6 +64,7 @@ describe('SspaParcel', () => {
         config.unmount.mockReturnValue(Promise.resolve());
 
         // Act.
+        // @ts-expect-error
         render(SspaParcel, { sspa: { config, mountParcel: mountRootParcel } });
         await delay(0);
 
@@ -88,6 +91,7 @@ describe('SspaParcel', () => {
         };
 
         // Act.
+        // @ts-expect-error
         render(SspaParcel, { sspa: { config, mountParcel: mountRootParcel }, ...props });
         await delay(0);
 
@@ -124,6 +128,7 @@ describe('SspaParcel', () => {
             a: 2,
             b: false
         };
+        // @ts-expect-error
         const component = render(SspaParcel, { sspa: { config, mountParcel: mountRootParcel }, ...props });
 
         // Act.
@@ -147,6 +152,7 @@ describe('SspaParcel', () => {
         const mountParcel = vi.fn();
 
         // Act.
+        // @ts-expect-error
         render(SspaParcel, { context: new Map([[singleSpaContextKey, { mountParcel }]]), props: { sspa: { config } } });
 
         // Assert.

--- a/src/lib/SspaParcel/SspaParcel.test.ts
+++ b/src/lib/SspaParcel/SspaParcel.test.ts
@@ -1,9 +1,9 @@
 import { singleSpaContextKey } from '$lib/singleSpaContext.js';
+import SspaParcel from '$lib/SspaParcel/SspaParcel.svelte';
 import { delay } from '$lib/utils.js';
 import { render } from '@testing-library/svelte';
 import { mountRootParcel } from 'single-spa';
 import { describe, expect, test, vi } from 'vitest';
-import { SspaParcel } from '../index.js';
 import type { SingleSpaProps } from '../wjfe-single-spa-svelte.js';
 
 describe('SspaParcel', () => {

--- a/src/lib/SspaParcel/SspaParcel.test.ts
+++ b/src/lib/SspaParcel/SspaParcel.test.ts
@@ -7,7 +7,24 @@ import { describe, expect, test, vi } from 'vitest';
 import type { SingleSpaProps } from '../wjfe-single-spa-svelte.js';
 
 describe('SspaParcel', () => {
-    test('Should throw an error if mountParcel is not provided.', () => {
+    test("Should obtain the mountParcel function from context.", () => {
+        // Arrange.
+        const config = {
+            bootstrap: vi.fn(),
+            mount: vi.fn(),
+            unmount: vi.fn(),
+            update: vi.fn()
+        };
+        const mountParcel = vi.fn();
+
+        // Act.
+        // @ts-expect-error
+        render(SspaParcel, { context: new Map([[singleSpaContextKey, { mountParcel }]]), props: { sspa: { config } } });
+
+        // Assert.
+        expect(mountParcel).toHaveBeenCalledOnce();
+    });
+    test('Should throw an error if mountParcel is not found in context.', () => {
         // Arrange.
         const config = {
             bootstrap: vi.fn(),
@@ -31,23 +48,6 @@ describe('SspaParcel', () => {
         // Assert.
         expect(act).toThrow();
     });
-    test("Should call the given mountParcel() function upon rendering.", () => {
-        // Arrange.
-        const config = {
-            bootstrap: vi.fn(),
-            mount: vi.fn(),
-            unmount: vi.fn(),
-            update: vi.fn()
-        };
-        const mountParcel = vi.fn();
-
-        // Act.
-        // @ts-expect-error
-        render(SspaParcel, { sspa: { config, mountParcel } });
-
-        // Assert.
-        expect(mountParcel).toHaveBeenCalledOnce();
-    });
     test("Should include the domElement property when calling the config's mount() function.", async () => {
         // Arrange.
         let sspaProps = {} as SingleSpaProps;
@@ -65,7 +65,10 @@ describe('SspaParcel', () => {
 
         // Act.
         // @ts-expect-error
-        render(SspaParcel, { sspa: { config, mountParcel: mountRootParcel } });
+        render(SspaParcel, {
+            context: new Map([[singleSpaContextKey, { mountParcel: mountRootParcel }]]),
+            props: { sspa: { config } }
+        });
         await delay(0);
 
         // Assert.
@@ -92,7 +95,10 @@ describe('SspaParcel', () => {
 
         // Act.
         // @ts-expect-error
-        render(SspaParcel, { sspa: { config, mountParcel: mountRootParcel }, ...props });
+        render(SspaParcel, {
+            context: new Map([[singleSpaContextKey, { mountParcel: mountRootParcel }]]),
+            props: { sspa: { config }, ...props }
+        });
         await delay(0);
 
         // Assert.
@@ -129,10 +135,13 @@ describe('SspaParcel', () => {
             b: false
         };
         // @ts-expect-error
-        const component = render(SspaParcel, { sspa: { config, mountParcel: mountRootParcel }, ...props });
+        const component = render(SspaParcel, {
+            context: new Map([[singleSpaContextKey, { mountParcel: mountRootParcel }]]),
+            props: { sspa: { config }, ...props }
+        });
 
         // Act.
-        await component.rerender({ sspa: { config, mountParcel: mountRootParcel }, ...newProps });
+        await component.rerender({ ...newProps });
         await delay(0);
 
         // Assert.
@@ -140,22 +149,5 @@ describe('SspaParcel', () => {
             // @ts-expect-error
             expect(updatedProps?.[k]).toEqual(v);
         }
-    });
-    test("Should obtain the mountParcel function from context.", () => {
-        // Arrange.
-        const config = {
-            bootstrap: vi.fn(),
-            mount: vi.fn(),
-            unmount: vi.fn(),
-            update: vi.fn()
-        };
-        const mountParcel = vi.fn();
-
-        // Act.
-        // @ts-expect-error
-        render(SspaParcel, { context: new Map([[singleSpaContextKey, { mountParcel }]]), props: { sspa: { config } } });
-
-        // Assert.
-        expect(mountParcel).toHaveBeenCalledOnce();
     });
 });

--- a/src/lib/SspaParcel/SspaParcel.test.ts
+++ b/src/lib/SspaParcel/SspaParcel.test.ts
@@ -1,3 +1,4 @@
+import { singleSpaContextKey } from '$lib/singleSpaContext.js';
 import { delay } from '$lib/utils.js';
 import { render } from '@testing-library/svelte';
 import { mountRootParcel } from 'single-spa';
@@ -16,7 +17,6 @@ describe('SspaParcel', () => {
         };
 
         // Act.
-        // @ts-expect-error
         const act = () => render(SspaParcel, { sspa: { config } });
 
         // Assert.
@@ -135,5 +135,21 @@ describe('SspaParcel', () => {
             // @ts-expect-error
             expect(updatedProps?.[k]).toEqual(v);
         }
+    });
+    test("Should obtain the mountParcel function from context.", () => {
+        // Arrange.
+        const config = {
+            bootstrap: vi.fn(),
+            mount: vi.fn(),
+            unmount: vi.fn(),
+            update: vi.fn()
+        };
+        const mountParcel = vi.fn();
+
+        // Act.
+        render(SspaParcel, { context: new Map([[singleSpaContextKey, { mountParcel }]]), props: { sspa: { config } } });
+
+        // Assert.
+        expect(mountParcel).toHaveBeenCalledOnce();
     });
 });

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+describe('index', () => {
+    test("Should export exactly the expected objects.", async () => {
+        // Arrange.
+        const expectedList = [
+            'getSingleSpaContext',
+            'SspaParcel',
+            'singleSpaSvelte'
+        ];
+
+        // Act.
+        const lib = await import('./index.js');
+
+        // Assert.
+        for (let item of expectedList) {
+            expect(item in lib, `The expected object ${item} is not exported.`).toEqual(true);
+        }
+        for (let key of Object.keys(lib)) {
+            expect(expectedList.includes(key), `The library exports object ${key}, which is not expected.`).toEqual(true);
+        }
+    });
+});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,8 +8,7 @@ import singleSpaSvelteFactory from './single-spa/single-spa.svelte.js';
  * Creates single-spa lifecycle functions for a Svelte v5 component.
  * @param component Svelte component to mount as a single-spa micro-frontend or parcel.
  * @param domElementGetter Optional function that returns the DOM element where the component is mounted.
- * @param svelteOptions Optional set of Svelte options for mounting.  Refer to Svelte's `mount()` function 
- * documentation for information about each option.
+ * @param options Optional set of options, including Svelve mounting options.
  * @returns An object containing the single-spa lifecycle functions for the component.
 */
 export const singleSpaSvelte = singleSpaSvelteFactory();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,7 @@
-// Reexport your entry components here
+export * from './single-spa/single-spa.svelte.js';
+export { getSingleSpaContext } from './singleSpaContext.js';
 export * from './SspaParcel/SspaParcel.svelte';
 export { default as SspaParcel } from './SspaParcel/SspaParcel.svelte';
-export * from './single-spa/single-spa.svelte.js';
 import singleSpaSvelteFactory from './single-spa/single-spa.svelte.js';
 
 /**

--- a/src/lib/single-spa/TestComponent.test.svelte
+++ b/src/lib/single-spa/TestComponent.test.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
+    import { getSingleSpaContext } from "$lib/singleSpaContext.js";
+    import { getContext } from "svelte";
+
     const {
         propA = false
     } : {
-        propA: boolean;
+        propA?: boolean;
     } = $props();
+
+    const sspaContext = getSingleSpaContext();
+    sspaContext?.library?.mountRootParcel?.();
+    // @ts-expect-error Arguments intentionally omitted.
+    sspaContext?.mountParcel?.();
+    getContext<Function>("extra")?.();
 </script>
 
 <div role="alert" data-propA={propA}></div>

--- a/src/lib/single-spa/single-spa.svelte.test.ts
+++ b/src/lib/single-spa/single-spa.svelte.test.ts
@@ -184,6 +184,51 @@ describe('singleSpaSvelte', () => {
             // Assert.
             expect(didThrow).toEqual(true);
         });
+        test('Should store the single-spa library instance and the mountParcel function in context.', async () => {
+            // Arrange.
+            const sspaProps = {
+                mountParcel: vi.fn(),
+                name: 'the-name',
+                singleSpa: {
+                    mountRootParcel: vi.fn()
+                }
+            };
+            const lc = singleSpaSvelteFactory()(TestComponent);
+
+            // Act.
+            await lc.mount(sspaProps);
+            // Clean-up.
+            await lc.unmount(sspaProps);
+
+            // Assert.
+            expect(sspaProps.mountParcel).toHaveBeenCalledOnce();
+            expect(sspaProps.singleSpa.mountRootParcel).toHaveBeenCalledOnce();
+        });
+        test('Should store the single-spa library instance and the mountParcel function in the incoming context.', async () => {
+            // Arrange.
+            const sspaProps = {
+                mountParcel: vi.fn(),
+                name: 'the-name',
+                singleSpa: {
+                    mountRootParcel: vi.fn()
+                }
+            };
+            const extraContext = vi.fn();
+            const context = new Map([
+                ["extra", extraContext]
+            ]);
+            const lc = singleSpaSvelteFactory()(TestComponent, undefined, { svelteOptions: { context }});
+
+            // Act.
+            await lc.mount(sspaProps);
+            // Clean-up.
+            await lc.unmount(sspaProps);
+
+            // Assert.
+            expect(sspaProps.mountParcel).toHaveBeenCalledOnce();
+            expect(sspaProps.singleSpa.mountRootParcel).toHaveBeenCalledOnce();
+            expect(extraContext).toHaveBeenCalledOnce();
+        });
     });
     describe('unmount', () => {
         test('Should throw an error if called when there is nothing mounted.', async () => {
@@ -338,6 +383,8 @@ describe('singleSpaSvelte', () => {
             // Assert.
             const element = screen.getByRole('alert');
             expect(element.getAttribute('data-propA')).toEqual("true");
+            // Clean-up.
+            await lc.unmount(sspaProps);
         });
     });
 });

--- a/src/lib/single-spa/single-spa.svelte.test.ts
+++ b/src/lib/single-spa/single-spa.svelte.test.ts
@@ -98,7 +98,7 @@ describe('singleSpaSvelte', () => {
         });
         test("Should call Svelte's mount().", async () => {
             // Arrange.
-            const mountProps: SvelteOptions<ComponentProps<TestComponent>> = {
+            const mountProps: SvelteOptions<ComponentProps<typeof TestComponent>> = {
                 props: {
                     propA: true
                 }

--- a/src/lib/single-spa/single-spa.svelte.test.ts
+++ b/src/lib/single-spa/single-spa.svelte.test.ts
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/svelte';
 import { type ComponentProps } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type { SvelteOptions } from '../wjfe-single-spa-svelte.js';
+import type { MountOptions } from '../wjfe-single-spa-svelte.js';
 import singleSpaSvelteFactory from './single-spa.svelte.js';
 import TestComponent from './TestComponent.test.svelte';
 
@@ -33,14 +33,14 @@ describe('singleSpaSvelte', () => {
         expect(lc.unmount).toBeTypeOf('function');
         expect(lc.update).toBeTypeOf('function');
     });
-    test('Should throw an error if options.svelteOptions define the "target" property.', () => {
+    test('Should throw an error if options.mountOptions define the "target" property.', () => {
         // Arrange.
         let didThrow = false;
 
         // Act.
         try {
-            //@ts-expect-error The target property is disallowed in svelteOptions.
-            singleSpaSvelte(TestComponent, undefined, { svelteOptions: { target: {} } });
+            //@ts-expect-error The target property is disallowed in mountOptions.
+            singleSpaSvelte(TestComponent, undefined, { mountOptions: { target: {} } });
         }
         catch {
             didThrow = true;
@@ -98,12 +98,12 @@ describe('singleSpaSvelte', () => {
         });
         test("Should call Svelte's mount().", async () => {
             // Arrange.
-            const mountProps: SvelteOptions<ComponentProps<typeof TestComponent>> = {
+            const mountProps: MountOptions<ComponentProps<typeof TestComponent>> = {
                 props: {
                     propA: true
                 }
             };
-            const lc = singleSpaSvelte(TestComponent, undefined, { svelteOptions: mountProps });
+            const lc = singleSpaSvelte(TestComponent, undefined, { mountOptions: mountProps });
 
             // Act.
             await lc.mount({
@@ -217,7 +217,7 @@ describe('singleSpaSvelte', () => {
             const context = new Map([
                 ["extra", extraContext]
             ]);
-            const lc = singleSpaSvelteFactory()(TestComponent, undefined, { svelteOptions: { context }});
+            const lc = singleSpaSvelteFactory()(TestComponent, undefined, { mountOptions: { context }});
 
             // Act.
             await lc.mount(sspaProps);

--- a/src/lib/single-spa/single-spa.svelte.ts
+++ b/src/lib/single-spa/single-spa.svelte.ts
@@ -56,13 +56,7 @@ function singleSpaSvelteFactory(
             this.target = chooseDomElementGetter(props, domElementGetter)();
             await options?.preMount?.(this.target);
             // Don't lose any potential incoming context.
-            let context: Map<any, any>;
-            if (options?.svelteOptions?.context) {
-                context = options.svelteOptions.context;
-            }
-            else {
-                context = new Map();
-            }
+            let context = options?.svelteOptions?.context ?? new Map();
             context.set(singleSpaContextKey, {
                 library: props.singleSpa,
                 mountParcel: props.mountParcel ?? props.singleSpa.mountRootParcel

--- a/src/lib/single-spa/single-spa.svelte.ts
+++ b/src/lib/single-spa/single-spa.svelte.ts
@@ -33,8 +33,8 @@ function singleSpaSvelteFactory(
         if (!component) {
             throw new Error('No component was passed to the function.');
         }
-        if ((options?.svelteOptions as any)?.target) {
-            throw new Error("Providing the 'target' option via 'svelteOptions' is disallowed.");
+        if ((options?.mountOptions as any)?.target) {
+            throw new Error("Providing the 'target' option via 'mountOptions' is disallowed.");
         }
         const thisValue = new SvelteLifeCycle<TProps>();
 
@@ -43,7 +43,7 @@ function singleSpaSvelteFactory(
                 throw new Error('Cannot mount:  The component is currently mounted.');
             }
             const mergedProps = {
-                ...options?.svelteOptions?.props,
+                ...options?.mountOptions?.props,
                 ...props
             };
             delete mergedProps.domElement;
@@ -56,13 +56,13 @@ function singleSpaSvelteFactory(
             this.target = chooseDomElementGetter(props, domElementGetter)();
             await options?.preMount?.(this.target);
             // Don't lose any potential incoming context.
-            let context = options?.svelteOptions?.context ?? new Map();
+            let context = options?.mountOptions?.context ?? new Map();
             context.set(singleSpaContextKey, {
                 library: props.singleSpa,
                 mountParcel: props.mountParcel ?? props.singleSpa.mountRootParcel
             });
             this.instance = mountFn(component, {
-                ...options?.svelteOptions,
+                ...options?.mountOptions,
                 context,
                 target: this.target,
                 props: this.props

--- a/src/lib/single-spa/single-spa.svelte.ts
+++ b/src/lib/single-spa/single-spa.svelte.ts
@@ -1,3 +1,4 @@
+import { singleSpaContextKey } from "$lib/singleSpaContext.js";
 import { mount, unmount, type Component } from "svelte";
 import type { DomElementGetterFunction, InheritedSingleSpaProps, LifecycleOptions, SingleSpaProps, SspaLifeCycles } from "../wjfe-single-spa-svelte.js";
 
@@ -39,7 +40,7 @@ function singleSpaSvelteFactory(
 
         async function mountComponent(this: SvelteLifeCycle<TProps>, props: SingleSpaProps) {
             if (this.instance) {
-                return Promise.reject(new Error('Cannot mount:  The component is currently mounted.'));
+                throw new Error('Cannot mount:  The component is currently mounted.');
             }
             const mergedProps = {
                 ...options?.svelteOptions?.props,
@@ -54,12 +55,29 @@ function singleSpaSvelteFactory(
             }
             this.target = chooseDomElementGetter(props, domElementGetter)();
             await options?.preMount?.(this.target);
-            this.instance = mountFn(component, { ...options?.svelteOptions, target: this.target, props: this.props });
+            // Don't lose any potential incoming context.
+            let context: Map<any, any>;
+            if (options?.svelteOptions?.context) {
+                context = options.svelteOptions.context;
+            }
+            else {
+                context = new Map();
+            }
+            context.set(singleSpaContextKey, {
+                library: props.singleSpa,
+                mountParcel: props.mountParcel ?? props.singleSpa.mountRootParcel
+            });
+            this.instance = mountFn(component, {
+                ...options?.svelteOptions,
+                context,
+                target: this.target,
+                props: this.props
+            });
         }
 
         async function unmountComponent(this: SvelteLifeCycle, props: SingleSpaProps) {
             if (!this.instance) {
-                return Promise.reject(new Error('Cannot unmount:  There is no component to unmount.'));
+                throw new Error('Cannot unmount:  There is no component to unmount.');
             }
             unmountFn(this.instance);
             await options?.postUnmount?.(this.target!);

--- a/src/lib/singleSpaContext.ts
+++ b/src/lib/singleSpaContext.ts
@@ -2,9 +2,9 @@ import { getContext } from "svelte";
 import type { SingleSpaContext } from "./wjfe-single-spa-svelte.js";
 
 /**
- * Defines the context key used to store single-spa's `mountParcel()` function.
+ * Defines the context key used to store single-spa's `mountParcel()` function and the library instance.
  */
-export const singleSpaContextKey = Symbol("mountParcel");
+export const singleSpaContextKey = Symbol("singleSpaSvelte");
 
 /**
  * Obtains the `single-spa` context, which is an object that contains the `single-spa` library instance and the 

--- a/src/lib/singleSpaContext.ts
+++ b/src/lib/singleSpaContext.ts
@@ -1,0 +1,16 @@
+import { getContext } from "svelte";
+import type { SingleSpaContext } from "./wjfe-single-spa-svelte.js";
+
+/**
+ * Defines the context key used to store single-spa's `mountParcel()` function.
+ */
+export const singleSpaContextKey = Symbol("mountParcel");
+
+/**
+ * Obtains the `single-spa` context, which is an object that contains the `single-spa` library instance and the 
+ * `mountParcel` function for the micro-frontend.
+ * @returns The stored `single-spa` context.
+ */
+export function getSingleSpaContext() {
+    return getContext<SingleSpaContext>(singleSpaContextKey);
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,28 @@
+import { setContext } from "svelte";
+import { singleSpaContextKey } from "./singleSpaContext.js";
+import type { MountParcelFn } from "./wjfe-single-spa-svelte.js";
+
 export function delay(timeout?: number) {
     return new Promise<void>((rs) => setTimeout(() => rs(), timeout));
+}
+
+/**
+ * Sets the special `"mountParcel"` context using the provided function as its value.
+ * 
+ * This is not needed in mounted micro-frontends because the context is automatically set when the micro-frontend's 
+ * root component is mounted.  This is only needed in root projects that mount parcels directly using `SspaParcel`.
+ * 
+ * @example
+ * ```html
+ * <script lang="ts">
+ *     import { mountRootParcel } from "single-spa";
+ * 
+ *     // Call the function during the root component's initialization phase.
+ *     setMountParcelContext(mountRootParcel);
+ * </script>
+ * ```
+ * @param mountParcelFn Either single-spa's `mountRootParcel()` function, or an equivalent parcel-mounting function.
+ */
+export function setMounParcelContext(mountParcelFn: MountParcelFn) {
+    setContext(singleSpaContextKey, mountParcelFn);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,3 @@
-export function delay(ms: number) {
-    let rslv: () => void;
-    const promise = new Promise<void>((rs, rj) => {
-        rslv = rs;
-    });
-    setTimeout(() => {
-        rslv();
-    }, ms);
-    return promise;
+export function delay(timeout?: number) {
+    return new Promise<void>((rs) => setTimeout(() => rs(), timeout));
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,28 +1,3 @@
-import { setContext } from "svelte";
-import { singleSpaContextKey } from "./singleSpaContext.js";
-import type { MountParcelFn } from "./wjfe-single-spa-svelte.js";
-
 export function delay(timeout?: number) {
     return new Promise<void>((rs) => setTimeout(() => rs(), timeout));
-}
-
-/**
- * Sets the special `"mountParcel"` context using the provided function as its value.
- * 
- * This is not needed in mounted micro-frontends because the context is automatically set when the micro-frontend's 
- * root component is mounted.  This is only needed in root projects that mount parcels directly using `SspaParcel`.
- * 
- * @example
- * ```html
- * <script lang="ts">
- *     import { mountRootParcel } from "single-spa";
- * 
- *     // Call the function during the root component's initialization phase.
- *     setMountParcelContext(mountRootParcel);
- * </script>
- * ```
- * @param mountParcelFn Either single-spa's `mountRootParcel()` function, or an equivalent parcel-mounting function.
- */
-export function setMounParcelContext(mountParcelFn: MountParcelFn) {
-    setContext(singleSpaContextKey, mountParcelFn);
 }

--- a/src/lib/wjfe-single-spa-svelte.d.ts
+++ b/src/lib/wjfe-single-spa-svelte.d.ts
@@ -101,6 +101,13 @@ export type MountParcelFn<TProps extends Record<string, any> = Record<string, an
 ) => Parcel<TProps>;
 
 /**
+ * Defines the contents of the `single-spa` library.
+ * 
+ * This should come from the `single-spa` package itself, so this type is a mere placeholder.
+ */
+export type SingleSpaLibrary = Record<string, any>;
+
+/**
  * Defines the properties that every micro-frontend and parcel receive from `single-spa`.
  */
 export type InheritedSingleSpaProps = {
@@ -109,9 +116,9 @@ export type InheritedSingleSpaProps = {
      */
     name: string;
     /**
-     * The entire `single-spa` library.
+     * The complete `single-spa` library instance.
      */
-    singleSpa: Record<string, any>;
+    singleSpa: SingleSpaLibrary;
     /**
      * Mounts a parcel instance in the `domElement` HTML element provided through the `props` parameter.
      */
@@ -170,4 +177,19 @@ export type LifecycleOptions<
      * Optional options for Svelte's `mount()` function.
      */
     svelteOptions?: SvelteOptions<TProps, TExports>;
+};
+
+/**
+ * Defines the shape of the context stored at the level of the root component (the component mounted via the 
+ * `singleSpaSvelte()` function).
+ */
+export type SingleSpaContext = {
+    /**
+     * The complete `single-spa` library instance.
+     */
+    library: SingleSpaLibrary;
+    /**
+     * The parcel-mounting function assigned to the micro-frontend.
+     */
+    mountParcel: MountParcelFn;
 };

--- a/src/lib/wjfe-single-spa-svelte.d.ts
+++ b/src/lib/wjfe-single-spa-svelte.d.ts
@@ -147,7 +147,7 @@ export type SingleSpaProps = InheritedSingleSpaProps & Record<string, any> & {
 /**
  * Options for Svelte's `mount()` function.
  */
-export type SvelteOptions<
+export type MountOptions<
     TProps extends Record<string, any> = Record<string, any>,
     TExports extends Record<string, any> = Record<string, any>
 > = Omit<Parameters<typeof mount<TProps, TExports>>['1'], 'target'>;
@@ -174,9 +174,10 @@ export type LifecycleOptions<
      */
     postUnmount?: (target: HTMLElement) => Promise<void> | void;
     /**
-     * Optional options for Svelte's `mount()` function.
+     * Optional options for Svelte's `mount()` function.  Refer to Svelte's `mount()` function documentation for 
+     * information about each option.
      */
-    svelteOptions?: SvelteOptions<TProps, TExports>;
+    mountOptions?: MountOptions<TProps, TExports>;
 };
 
 /**


### PR DESCRIPTION
This eliminates the need for the `sspa.mountParcel` property in the `SspaParcel` component, and paves the way towards eliminating all single-spa-injected props from the mounted component.

This is particularly convenient because it frees the prop names for custom use (the `name` prop is particularly generic).