### PR TITLE
fix: Improve typings

### DIFF
--- a/src/lib/single-spa/single-spa.svelte.ts
+++ b/src/lib/single-spa/single-spa.svelte.ts
@@ -29,7 +29,7 @@ function singleSpaSvelteFactory(
         component: Component<TProps>,
         domElementGetter?: DomElementGetterFunction,
         options?: LifecycleOptions<TProps>
-    ): SspaLifeCycles<TProps> {
+    ): Required<SspaLifeCycles<TProps>> {
         if (!component) {
             throw new Error('No component was passed to the function.');
         }

--- a/src/lib/single-spa/single-spa.svelte.ts
+++ b/src/lib/single-spa/single-spa.svelte.ts
@@ -29,12 +29,12 @@ function singleSpaSvelteFactory(
         component: Component<TProps>,
         domElementGetter?: DomElementGetterFunction,
         options?: LifecycleOptions<TProps>
-    ): Required<SspaLifeCycles<TProps>> {
+    ) {
         if (!component) {
             throw new Error('No component was passed to the function.');
         }
         if ((options?.mountOptions as any)?.target) {
-            throw new Error("Providing the 'target' option via 'mountOptions' is disallowed.");
+            console.warn("Specifying the 'target' mount option has no effect.");
         }
         const thisValue = new SvelteLifeCycle<TProps>();
 
@@ -94,7 +94,7 @@ function singleSpaSvelteFactory(
             mount: mountComponent.bind(thisValue),
             unmount: unmountComponent.bind(thisValue),
             update: updateComponent.bind(thisValue)
-        };
+        } satisfies SspaLifeCycles<TProps>;
     }
 }
 

--- a/src/lib/wjfe-single-spa-svelte.d.ts
+++ b/src/lib/wjfe-single-spa-svelte.d.ts
@@ -21,15 +21,15 @@ export type SspaLifeCycles<TProps extends Record<string, any> = Record<string, a
     /**
      * Bootstrapping function that is called once by `single-spa`.
      */
-    bootstrap: LifecycleFunction;
+    bootstrap: LifecycleFunction | LifecycleFunction[];
     /**
      * Mounts the micro-frontend or parcel.
      */
-    mount: LifecycleFunction;
+    mount: LifecycleFunction | LifecycleFunction[];
     /**
      * Unmounts the micro-frontend or parcel.
      */
-    unmount: LifecycleFunction;
+    unmount: LifecycleFunction | LifecycleFunction[];
     /**
      * Updates the properties passed to the parcel.
      * @param props Updated set of properties for the parcel.
@@ -37,6 +37,16 @@ export type SspaLifeCycles<TProps extends Record<string, any> = Record<string, a
      */
     update: (props: TProps) => Promise<void>;
 };
+
+/**
+ * Defines the shape of configuration objects, which are the objects used to mount parcels.
+ */
+export type SspaParcelConfigObject<TProps extends Record<string, any> = Record<string, any>> = {
+    /**
+     * Parcel's assigned name.
+     */
+    name?: string;
+} & SspaLifeCycles<TProps>;
 
 /**
  * Defines the single-spa parcel object.
@@ -96,7 +106,7 @@ type Parcel<TProps extends Record<string, any> = Record<string, any>> = {
 * @returns The `single-spa` parcel object.
 */
 export type MountParcelFn<TProps extends Record<string, any> = Record<string, any>> = (
-    config: SspaLifeCycles | (() => Promise<SspaLifeCycles>),
+    config: SspaParcelConfigObject<TProps> | (() => Promise<SspaParcelConfigObject<TProps>>),
     props: TProps & { domElement: HTMLElement },
 ) => Parcel<TProps>;
 

--- a/src/lib/wjfe-single-spa-svelte.d.ts
+++ b/src/lib/wjfe-single-spa-svelte.d.ts
@@ -35,7 +35,7 @@ export type SspaLifeCycles<TProps extends Record<string, any> = Record<string, a
      * @param props Updated set of properties for the parcel.
      * @returns A promise that resolves once the update has completed.
      */
-    update: (props: TProps) => Promise<void>;
+    update?: (props: TProps) => Promise<void>;
 };
 
 /**
@@ -47,6 +47,12 @@ export type SspaParcelConfigObject<TProps extends Record<string, any> = Record<s
      */
     name?: string;
 } & SspaLifeCycles<TProps>;
+
+/**
+ * Defines the shape of the `mount` lifecycle function's `config` parameter.
+ */
+export type SspaParcelConfig<TProps extends Record<string, any> = Record<string, any>> =
+    SspaParcelConfigObject<TProps> | (() => Promise<SspaParcelConfigObject<TProps>>);
 
 /**
  * Defines the single-spa parcel object.
@@ -106,7 +112,7 @@ type Parcel<TProps extends Record<string, any> = Record<string, any>> = {
 * @returns The `single-spa` parcel object.
 */
 export type MountParcelFn<TProps extends Record<string, any> = Record<string, any>> = (
-    config: SspaParcelConfigObject<TProps> | (() => Promise<SspaParcelConfigObject<TProps>>),
+    config: SspaParcelConfig<TProps>,
     props: TProps & { domElement: HTMLElement },
 ) => Parcel<TProps>;
 
@@ -145,6 +151,8 @@ export type SingleSpaProps = InheritedSingleSpaProps & Record<string, any> & {
      * **NOTE**:  Techincally speaking, micro-frontends could be mounted using this, but it goes against the 
      * `single-spa` guidelines and this information is undocumented API and therefore subject to change without prior 
      * notice.
+     * 
+     * The primary (and probably **only**) purpose of this is to mount parcels.
      */
     domElement?: HTMLElement;
     /**


### PR DESCRIPTION
The error that was being thrown on target specification is also gone, as it has no real value.  Any target specification is simply ignored.